### PR TITLE
Fix Legendre elliptic-integral reductions at degenerate arguments

### DIFF
--- a/src/legendre/ellipeinc.rs
+++ b/src/legendre/ellipeinc.rs
@@ -138,7 +138,10 @@ pub fn ellipeinc_unchecked<T: Float>(phi: T, m: T) -> Result<T, StrErr> {
         rphi = pi_2!() - rphi;
     }
 
-    let mut result = if m > 0.0 && rphi.powi(3) * m / 6.0 < epsilon!() * rphi.abs() {
+    let mut result = if rphi == 0.0 || (m > 0.0 && rphi.powi(3) * m / 6.0 < epsilon!() * rphi.abs())
+    {
+        // rphi == 0 at phi = k*pi: the reduced-angle part is 0, so skip the Carlson block
+        // (which would divide by sin²(rphi) = 0) and keep only the m*mm*E(m) period term.
         // See http://functions.wolfram.com/EllipticIntegrals/EllipticE2/06/01/03/0001/
         s * rphi
     } else {
@@ -177,6 +180,25 @@ mod tests {
     #[test]
     fn test_ellipeinc() {
         compare_test_data_boost!("ellipeinc_data.txt", ellipeinc, 2, 5e-16);
+    }
+
+    #[test]
+    fn test_ellipeinc_multiple_of_pi() {
+        // E(k*pi, m) = 2k E(m); previously errored for m not in {0, 1} because the
+        // reduced angle is 0 (sin^2 = 0). Reference values from mpmath.
+        use crate::util::assert_close;
+        use std::f64::consts::PI;
+        assert_close(ellipeinc(PI, 0.5).unwrap(), 2.7012877620953509, 1e-14);
+        assert_close(ellipeinc(2.0 * PI, 0.5).unwrap(), 5.4025755241907018, 1e-14);
+        assert_close(ellipeinc(3.0 * PI, 0.5).unwrap(), 8.1038632862860526, 1e-14);
+        assert_close(ellipeinc(-PI, 0.5).unwrap(), -2.7012877620953509, 1e-14);
+        assert_close(ellipeinc(PI, -0.5).unwrap(), 3.5035425513896356, 1e-14);
+        assert_close(ellipeinc(PI, -10.0).unwrap(), 7.2782760768355362, 1e-14);
+        assert_close(ellipeinc(PI, 0.9999).unwrap(), 2.0005491648613258, 1e-14);
+        // Period-doubling identity E(pi, m) = 2 E(m) (oracle-free check).
+        for &m in &[0.5, -0.5, 0.9999, 0.1] {
+            assert_close(ellipeinc(PI, m).unwrap(), 2.0 * ellipe(m).unwrap(), 1e-14);
+        }
     }
 
     #[test]

--- a/src/legendre/ellippi.rs
+++ b/src/legendre/ellippi.rs
@@ -138,6 +138,11 @@ pub fn ellippi_unchecked<T: Float>(n: T, m: T) -> T {
             return ellipk(m).unwrap_or(nan!());
         }
         // n < 0: ellippi(n,m)
+        // On the diagonal, Π(n, n) = E(n) / (1 - n) (https://dlmf.nist.gov/19.6.E1).
+        // The A&S 17.7.17 form below divides by m - n, so handle m = n directly.
+        if m == n {
+            return ellipe(m).unwrap_or(nan!()) / (1.0 - m);
+        }
         // Apply A&S 17.7.17
         let nn = (m - n) / (1.0 - n);
         let nm1 = (1.0 - m) / (1.0 - n);
@@ -196,6 +201,33 @@ mod tests {
     #[test]
     fn test_ellippi_wolfram_pv() {
         compare_test_data_wolfram!("ellippi_pv.csv", ellippi, 2, 1e-14);
+    }
+
+    #[test]
+    fn test_ellippi_negative_diagonal() {
+        // Pi(n, n) = E(n) / (1 - n) for n < 1. Previously errored for n = m < 0 because
+        // the A&S 17.7.17 branch divides by m - n. Reference values from mpmath.
+        use crate::util::assert_close;
+        assert_close(ellippi(-0.5, -0.5).unwrap(), 1.1678475171298786, 1e-14);
+        assert_close(ellippi(-2.0, -2.0).unwrap(), 0.72814604758206706, 1e-14);
+        assert_close(ellippi(-10.0, -10.0).unwrap(), 0.33083073076525165, 1e-14);
+        assert_close(ellippi(-100.0, -100.0).unwrap(), 0.10108179128529279, 1e-14);
+        assert_close(
+            ellippi(-1000.0, -1000.0).unwrap(),
+            0.031675528525186074,
+            1e-14,
+        );
+        // Consistency with the closed form and with the (already handled) n = m > 0 diagonal.
+        assert_close(
+            ellippi(-0.5, -0.5).unwrap(),
+            ellipe(-0.5).unwrap() / 1.5,
+            1e-14,
+        );
+        assert_close(
+            ellippi(0.5, 0.5).unwrap(),
+            ellipe(0.5).unwrap() / 0.5,
+            1e-14,
+        );
     }
 
     #[test]

--- a/src/legendre/ellippiinc.rs
+++ b/src/legendre/ellippiinc.rs
@@ -168,7 +168,9 @@ fn ellippiinc_vc<T: Float>(phi: T, n: T, m: T, nc: T) -> Result<T, StrErr> {
             }
 
             result = sign * ellippiinc_vc(rphi, n, m, nc)?;
-            if mm > 0.0 && nc > 0.0 {
+            // Add the whole-period term for every characteristic, including n > 1
+            // (nc = 1 - n < 0), where ellippi_vc returns the Cauchy principal value.
+            if mm > 0.0 {
                 result = result + mm * ellippi_vc(n, m, nc);
             }
         }
@@ -486,6 +488,62 @@ mod tests {
             ellippiinc(0.5, 0.5, NAN),
             Err("ellippiinc: Arguments cannot be NAN.")
         );
+    }
+
+    #[test]
+    fn test_ellippiinc_pv_period_reduction() {
+        // phi > pi/2 with n > 1: the whole-period term Pi(n, m) (a Cauchy principal
+        // value when n > 1) must be added. Reference values from mpmath (real part).
+        use crate::util::assert_close;
+        use std::f64::consts::PI;
+        assert_close(
+            ellippiinc(1.8, 2.0, 0.5).unwrap(),
+            -0.64674706139956679,
+            1e-13,
+        );
+        assert_close(
+            ellippiinc(2.5, 2.0, 0.5).unwrap(),
+            -1.6381653646511639,
+            1e-13,
+        );
+        assert_close(
+            ellippiinc(PI, 2.0, 0.5).unwrap(),
+            -0.62708936693036821,
+            1e-13,
+        );
+        assert_close(
+            ellippiinc(2.0 * PI, 2.0, 0.5).unwrap(),
+            -1.2541787338607364,
+            1e-13,
+        );
+        assert_close(
+            ellippiinc(4.0, 2.0, 0.5).unwrap(),
+            0.73728081706497557,
+            1e-13,
+        );
+        assert_close(
+            ellippiinc(3.0, 5.0, 0.3).unwrap(),
+            -0.25933770747965593,
+            1e-13,
+        );
+        assert_close(
+            ellippiinc(5.0, 3.0, 0.7).unwrap(),
+            -1.2918432212584487,
+            1e-13,
+        );
+        assert_close(
+            ellippiinc(PI, 2.0, -1.0).unwrap(),
+            0.44341914376644227,
+            1e-13,
+        );
+        // Period-doubling identity Pi(pi, n, m) = 2 Pi(n, m) (oracle-free check).
+        for &(n, m) in &[(2.0, 0.5), (5.0, 0.3), (1.5, 0.9), (0.5, 0.5), (-0.5, 0.3)] {
+            assert_close(
+                ellippiinc(PI, n, m).unwrap(),
+                2.0 * ellippi(n, m).unwrap(),
+                1e-13,
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Three functions in the Legendre reduction give a wrong result or an error where a finite value exists. All three are in argument ranges the vendored Boost/Wolfram data doesn't reach (φ never exceeds π/2 for n > 1; no test row lands on a multiple of π; the n = m diagonal has no negative points), so they slipped past the suite.

```rust
use ellip::{ellippiinc, ellipeinc, ellippi};
use std::f64::consts::PI;
ellippiinc(2.0 * PI, 2.0, 0.5); // Ok(0.0)   -> should be -1.2541787338607
ellipeinc(PI, 0.5);             // Err(...)  -> should be  2.7012877620953
ellippi(-0.5, -0.5);            // Err(...)  -> should be  1.1678475171299
```

`ellippiinc(φ, n, m)` for φ > π/2, n > 1: the whole-period term `mm·Π(n, m)` is added only when `nc = 1 - n > 0`, so for the circular case n > 1 it is dropped and the result is wrong for every φ > π/2 (the error grows with φ, and is exactly 0 at multiples of π). `ellippi_vc` already returns the Cauchy principal value for n > 1 (through `elliprj`'s p < 0 branch) — it is the same value `ellippiinc(π/2, n, m)` already returns — so the fix is just to drop the `nc > 0` condition.

`ellipeinc(kπ, m)` for m ∉ {0, 1}: at φ = kπ the reduced angle is 0, so `1/sin²φ` is infinite and the Carlson block yields NaN. `ellipdinc` and `ellipf` already skip the reduced part when it is 0; doing the same here gives `E(kπ, m) = 2k·E(m)`.

`ellippi(n, n)` for n < 0: the A&S 17.7.17 branch divides by `m − n`, which is 0 on the diagonal. The existing `Π(n, n) = E(n)/(1 − n)` special case sits in the n > 0 path and is unreachable for n < 0; handling the diagonal before the transform fixes it.

Reference values are from mpmath (40 digits), cross-checked against SciPy's Carlson `R_J` and the exact doubling identities F(π) = 2K, E(π) = 2E, Π(π, n, m) = 2Π(n, m). The new tests cover each regime and add an oracle-free doubling-identity check; the existing Boost/Wolfram suites are unchanged and still pass.

Not addressed here: near (but not on) the negative diagonal, `Π(n, m)` with n < 0 loses precision as m → n because the A&S transform cancels in `m − n` (~1e-2 relative error at |m − n| = 1e-14, n = -0.5). The direct Carlson form `K(m) + n/3·R_J(0, 1−m, 1, 1−n)` is accurate there, but it is less accurate than A&S for large |n| off the diagonal (it exceeds the 4.4e-16 boost tolerance around n = -87), so I didn't switch wholesale. Happy to add a near-diagonal branch if you'd like that covered too.
